### PR TITLE
Fix Docker build by installing dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ COPY package*.json ./
 COPY bun.lockb ./
 
 # Install dependencies
-RUN npm ci --only=production
+# We need devDependencies (like Vite) present during the build stage, so do not omit them here.
+RUN npm ci
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary
- install all npm dependencies during the Docker build so dev-only tools like Vite are available
- document in the Dockerfile why devDependencies must be included for the build stage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf29dbe3688326a217b050a8e6c898